### PR TITLE
use RelayState for redirect if available

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -173,6 +173,8 @@ def acs(r):
     saml_client = _get_saml_client(get_current_domain(r))
     resp = r.POST.get('SAMLResponse', None)
     next_url = r.session.get('login_next_url', _default_next_url())
+    # Use RelayState if available, else fall back to next_url.
+    next_url = r.POST.get('RelayState', next_url)
 
     if not resp:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
@@ -272,7 +274,7 @@ def signin(r):
     r.session['login_next_url'] = next_url
 
     saml_client = _get_saml_client(get_current_domain(r))
-    _, info = saml_client.prepare_for_authenticate(binding=BINDING_HTTP_POST)
+    _, info = saml_client.prepare_for_authenticate(binding=BINDING_HTTP_POST, relay_state=next_url)
 
     if info["method"] == "GET":
         redirect_url = None


### PR DESCRIPTION
- Use SAML2 `RelayState` if available for redirect. Apparently `RelayState` is a de-facto standard for "what URL the SP should redirect to after successful sign on" as explained [here](https://stackoverflow.com/a/34351756) and in the parameter of the `pysaml2` code [here](https://github.com/IdentityPython/pysaml2/blob/master/src/saml2/client.py#L58).

This PR is inspired by https://github.com/fangli/django-saml2-auth/pull/118